### PR TITLE
fix length property annotation

### DIFF
--- a/src/Blogger/BlogBundle/Entity/Blog.php
+++ b/src/Blogger/BlogBundle/Entity/Blog.php
@@ -40,7 +40,7 @@ class Blog
     protected $blog;
     
     /**
-     * @ORM\Column(type="string", length="20")
+     * @ORM\Column(type="string", length=20)
      */
     protected $image;
     


### PR DESCRIPTION
length="20" throw error in doctrine 2.2:

[Type Error] Attribute "length" of @ORM\Column declared on property Blogger\BlogBundle\Entity\Blog::$image expects a(n) integer, but got string
